### PR TITLE
fix: allow manual trigger of `release.yaml`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,10 @@ on:
   push:
     branches:
       - main
-  workflow_call:
-
+    paths-ignore:
+      - '.github/**'
+      - '**.md'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
also ignore non-release paths