### PR TITLE
fix: prevent the failing requests that occur the moment the "wait until" time given by a retriable 4XX error is reached

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0
 	github.com/die-net/lrucache v0.0.0-20220628165024-20a71bc65bf1
 	github.com/fasthttp/router v1.4.11
-	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-github/v45 v45.2.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/prometheus/client_golang v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,6 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
-github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v45 v45.2.0 h1:5oRLszbrkvxDDqBCNj2hjDZMKmvexaZ1xw/FCD+K3FI=
 github.com/google/go-github/v45 v45.2.0/go.mod h1:FObaZJEDSTa/WGCzZ2Z3eoCDXWJKMenWWTrd8jrta28=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/pkg/metrics/get_billable_from_github.go
+++ b/pkg/metrics/get_billable_from_github.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"math/rand"
 	"net/http"
@@ -11,7 +12,7 @@ import (
 
 	"github.com/faubion-hbo/github-actions-exporter/pkg/config"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v45/github"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -35,8 +36,7 @@ func getBillableFromGithub() {
 				for {
 					usage, resp, err := client.Actions.GetWorkflowUsageByID(context.Background(), r[0], r[1], k)
 					if rl_err, ok := err.(*github.RateLimitError); ok {
-						log.Printf("GetWorkflowUsageByID ratelimited. Pausing until %s", rl_err.Rate.Reset.Time.String())
-						time.Sleep(time.Until(rl_err.Rate.Reset.Time))
+						handleTokenExhausted(fmt.Sprintf("%s, %d", repo, k), "Actions.GetWorkflowUsageByID", *rl_err)
 						continue
 					} else if err != nil {
 						if resp.StatusCode == http.StatusForbidden {

--- a/pkg/metrics/get_runners_enterprise_from_github.go
+++ b/pkg/metrics/get_runners_enterprise_from_github.go
@@ -31,8 +31,7 @@ func getAllEnterpriseRunners() []*github.Runner {
 	for {
 		resp, rr, err := client.Enterprise.ListRunners(context.Background(), config.EnterpriseName, nil)
 		if rl_err, ok := err.(*github.RateLimitError); ok {
-			log.Printf("ListRunners ratelimited. Pausing until %s", rl_err.Rate.Reset.Time.String())
-			time.Sleep(time.Until(rl_err.Rate.Reset.Time))
+			handleTokenExhausted(config.EnterpriseName, "Enterprise.ListRunners", *rl_err)
 			continue
 		} else if err != nil {
 			if rr.StatusCode == http.StatusForbidden {

--- a/pkg/metrics/get_runners_from_github.go
+++ b/pkg/metrics/get_runners_from_github.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"math/rand"
 	"net/http"
@@ -32,8 +33,7 @@ func getAllRepoRunners(owner string, repo string) []*github.Runner {
 	for {
 		resp, rr, err := client.Actions.ListRunners(context.Background(), owner, repo, opt)
 		if rl_err, ok := err.(*github.RateLimitError); ok {
-			log.Printf("ListRunners ratelimited. Pausing until %s", rl_err.Rate.Reset.Time.String())
-			time.Sleep(time.Until(rl_err.Rate.Reset.Time))
+			handleTokenExhausted(fmt.Sprintf("%s/%s", owner, repo), "Actions.ListRunners", *rl_err)
 			continue
 		} else if err != nil {
 			if rr.StatusCode == http.StatusForbidden {

--- a/pkg/metrics/get_runners_organization_from_github.go
+++ b/pkg/metrics/get_runners_organization_from_github.go
@@ -31,8 +31,7 @@ func getAllOrgRunners(orga string) []*github.Runner {
 	for {
 		resp, rr, err := client.Actions.ListOrganizationRunners(context.Background(), orga, opt)
 		if rl_err, ok := err.(*github.RateLimitError); ok {
-			log.Printf("ListOrganizationRunners ratelimited. Pausing until %s", rl_err.Rate.Reset.Time.String())
-			time.Sleep(time.Until(rl_err.Rate.Reset.Time))
+			handleTokenExhausted(orga, "Actions.ListOrganizationRunners", *rl_err)
 			continue
 		} else if err != nil {
 			if rr.StatusCode == http.StatusForbidden {

--- a/pkg/metrics/github_fetcher.go
+++ b/pkg/metrics/github_fetcher.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"math/rand"
 	"net/http"
@@ -9,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v45/github"
-
 	"github.com/faubion-hbo/github-actions-exporter/pkg/config"
+
+	"github.com/google/go-github/v45/github"
 )
 
 type orgRepos struct {
@@ -33,8 +34,7 @@ func countAllReposForOrg(orga string) int {
 	for {
 		organization, _, err := client.Organizations.Get(context.Background(), orga)
 		if rl_err, ok := err.(*github.RateLimitError); ok {
-			log.Printf("Organizations ratelimited. Pausing until %s", rl_err.Rate.Reset.Time.String())
-			time.Sleep(time.Until(rl_err.Rate.Reset.Time))
+			handleTokenExhausted(orga, "Organizations.Get", *rl_err)
 			continue
 		} else if err != nil {
 			log.Printf("Get error for %s: %s", orga, err.Error())
@@ -60,8 +60,7 @@ func getAllReposForOrg(orga string) orgRepos {
 	for {
 		repos_page, resp, err := client.Repositories.ListByOrg(context.Background(), orga, opt)
 		if rl_err, ok := err.(*github.RateLimitError); ok {
-			log.Printf("ListByOrg ratelimited. Pausing until %s", rl_err.Rate.Reset.Time.String())
-			time.Sleep(time.Until(rl_err.Rate.Reset.Time))
+			handleTokenExhausted(orga, "Repositories.ListByOrg", *rl_err)
 			continue
 		} else if err != nil {
 			log.Printf("ListByOrg error for %s: %s", orga, err.Error())
@@ -109,8 +108,7 @@ func getAllWorkflowsForRepo(owner string, repo string) map[int64]github.Workflow
 	for {
 		workflows_page, resp, err := client.Actions.ListWorkflows(context.Background(), owner, repo, opt)
 		if rl_err, ok := err.(*github.RateLimitError); ok {
-			log.Printf("ListWorkflows ratelimited. Pausing until %s", rl_err.Rate.Reset.Time.String())
-			time.Sleep(time.Until(rl_err.Rate.Reset.Time))
+			handleTokenExhausted(fmt.Sprintf("%s/%s", owner, repo), "Actions.ListWorkflows", *rl_err)
 			continue
 		} else if err != nil {
 			if resp.StatusCode == http.StatusForbidden {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,12 +4,12 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/faubion-hbo/github-actions-exporter/pkg/config"
+	"github.com/faubion-hbo/github-actions-exporter/pkg/metrics"
+
 	"github.com/fasthttp/router"
 	"github.com/urfave/cli/v2"
 	"github.com/valyala/fasthttp"
-
-	"github.com/faubion-hbo/github-actions-exporter/pkg/config"
-	"github.com/faubion-hbo/github-actions-exporter/pkg/metrics"
 )
 
 // RunServer - run http server for expose metrics


### PR DESCRIPTION
not pictured: logs where right at the moment the thread was told to wait until for an error response from gh we have multiple, rapid requests that fail because the server is still saying that, e.g. the token is expired.

this buffer of a couple `s` will make sure that the token is refreshed on gh's side before retrying
