### PR TITLE
feat: add metric to track remaining limits for `core`, `search`, and `graphql`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,21 @@ github-actions-exporter for `prometheus`
 
 ## Running locally
 
-First, ensure you have `grafana` installed and running.
+You can start the exporter by first building it with:
 
-Create some file, e.g. `/tmp/prometheus.yml`, copy the default `prometheus` config, then include:
+```sh
+make build
+```
+
+Then start it up with (in the case of wanting to use a GitHub App):
+
+```sh
+./bin/app --gai <GitHub App ID> --gii <GitHub App Installation ID> --gpk <path to .pem file> --github_repos <test>/<repo>
+```
+
+Next, ensure you have `grafana` installed and running.
+
+Then, create some file, e.g. `/tmp/prometheus.yml`, copy the default `prometheus` config, then include:
 
 ```yaml
 scrape_configs:
@@ -19,7 +31,7 @@ scrape_configs:
     #- host.containers.internal:9999
 ```
 
-Then start up `prometheus` with your container tool of choice, e.g. `docker`:
+Finally, you can then run `prometheus` with your favorite container tool, e.g. `docker`:
 
 ```sh
 docker run \
@@ -27,7 +39,7 @@ docker run \
   -p 9090:9090 prom/prometheus
 ```
 
-In `grafana`, added the local `prometheus` as a data source, and you're good to go!
+From within `grafana`, added the local `prometheus` as a data source, and you're good to start querying data!
 
 ___
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,40 @@
-> [!WARNING]  
-> Below information has not been validated by me
+# github-actions-exporter
+github-actions-exporter for `prometheus`
+
+## Running locally
+
+First, ensure you have `grafana` installed and running.
+
+Create some file, e.g. `/tmp/prometheus.yml`, copy the default `prometheus` config, then include:
+
+```yaml
+scrape_configs:
+...
+- job_name: github-actions-exporter
+  scrape_interval: 5s
+  static_configs:
+  - targets:
+    - host.docker.internal:9999
+    # if using `podman`, use:
+    #- host.containers.internal:9999
+```
+
+Then start up `prometheus` with your container tool of choice, e.g. `docker`:
+
+```sh
+docker run \
+  -v /tmp/prometheus.yml:/etc/prometheus/prometheus.yml \
+  -p 9090:9090 prom/prometheus
+```
+
+In `grafana`, added the local `prometheus` as a data source, and you're good to go!
 
 ___
 
-## Change of organization
-The project was migrated to another organization because it was no longer maintained.
-In the coming weeks, changes will be made on various points (code and container image) and also an update of all the libraries.
-If there are feature requests, you can make them in the issues. For a better understanding of the requested features, having a detailed description or example will be greatly appreciated.
+> [!WARNING]
+> Below information comes from fork source and has yet to be validated by me
 
-# github-actions-exporter
-github-actions-exporter for prometheus
+___
 
 ![Release pipeline](https://github.com/Labbs/github-actions-exporter/actions/workflows/release.yml/badge.svg)
 

--- a/pkg/metrics/get_rate_limits_from_github.go
+++ b/pkg/metrics/get_rate_limits_from_github.go
@@ -2,8 +2,6 @@ package metrics
 
 import (
 	"context"
-	"crypto/sha256"
-	"fmt"
 	"log"
 	"math/rand"
 	"net/http"
@@ -20,7 +18,7 @@ var (
 			Name: "github_remaining_limits",
 			Help: "remaining limits",
 		},
-		[]string{"app_id", "type"},
+		[]string{"type"},
 	)
 )
 
@@ -50,19 +48,14 @@ func getRateLimits() (*github.RateLimits, int) {
 }
 
 // getRemainingLimitsFromGithub - return information about the remaining limits for this GitHub client's credentials
-func getRemainingLimitsFromGithub(appId string) {
-	appIdBytes := []byte(appId)
-	hashedAppIdBytes := sha256.New()
-	hashedAppIdBytes.Write(appIdBytes)
-	hashedAppId := fmt.Sprintf("%x", hashedAppIdBytes.Sum(nil))
-
+func getRemainingLimitsFromGithub() {
 	for {
 		rateLimits, secondsBetween := getRateLimits()
 
 		if rateLimits != nil {
-			remainingLimitsGauge.WithLabelValues(hashedAppId, "core").Set(float64(rateLimits.GetCore().Remaining))
-			remainingLimitsGauge.WithLabelValues(hashedAppId, "search").Set(float64(rateLimits.GetSearch().Remaining))
-			remainingLimitsGauge.WithLabelValues(hashedAppId, "graphql").Set(float64(rateLimits.GetGraphQL().Remaining))
+			remainingLimitsGauge.WithLabelValues("core").Set(float64(rateLimits.GetCore().Remaining))
+			remainingLimitsGauge.WithLabelValues("search").Set(float64(rateLimits.GetSearch().Remaining))
+			remainingLimitsGauge.WithLabelValues("graphql").Set(float64(rateLimits.GetGraphQL().Remaining))
 		}
 
 		time.Sleep(time.Duration(secondsBetween) * time.Second)

--- a/pkg/metrics/get_rate_limits_from_github.go
+++ b/pkg/metrics/get_rate_limits_from_github.go
@@ -2,6 +2,8 @@ package metrics
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"log"
 	"math/rand"
 	"net/http"
@@ -18,7 +20,7 @@ var (
 			Name: "github_remaining_limits",
 			Help: "remaining limits",
 		},
-		[]string{"type"},
+		[]string{"app_id", "type"},
 	)
 )
 
@@ -48,14 +50,19 @@ func getRateLimits() (*github.RateLimits, int) {
 }
 
 // getRemainingLimitsFromGithub - return information about the remaining limits for this GitHub client's credentials
-func getRemainingLimitsFromGithub() {
+func getRemainingLimitsFromGithub(appId string) {
+	appIdBytes := []byte(appId)
+	hashedAppIdBytes := sha256.New()
+	hashedAppIdBytes.Write(appIdBytes)
+	hashedAppId := fmt.Sprintf("%x", hashedAppIdBytes.Sum(nil))
+
 	for {
 		rateLimits, secondsBetween := getRateLimits()
 
 		if rateLimits != nil {
-			remainingLimitsGauge.WithLabelValues("core").Set(float64(rateLimits.GetCore().Remaining))
-			remainingLimitsGauge.WithLabelValues("search").Set(float64(rateLimits.GetSearch().Remaining))
-			remainingLimitsGauge.WithLabelValues("graphql").Set(float64(rateLimits.GetGraphQL().Remaining))
+			remainingLimitsGauge.WithLabelValues(hashedAppId, "core").Set(float64(rateLimits.GetCore().Remaining))
+			remainingLimitsGauge.WithLabelValues(hashedAppId, "search").Set(float64(rateLimits.GetSearch().Remaining))
+			remainingLimitsGauge.WithLabelValues(hashedAppId, "graphql").Set(float64(rateLimits.GetGraphQL().Remaining))
 		}
 
 		time.Sleep(time.Duration(secondsBetween) * time.Second)

--- a/pkg/metrics/get_rate_limits_from_github.go
+++ b/pkg/metrics/get_rate_limits_from_github.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	remainingLimitsGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "github_remaining_limits",
+			Help: "remaining limits",
+		},
+		[]string{"type"},
+	)
+)
+
+var rateLimitsQuerySecondsBetween = 5
+
+func getRateLimits() (*github.RateLimits, int) {
+	rateLimits, resp, err := client.RateLimits(context.Background())
+
+	if rl_err, ok := err.(*github.RateLimitError); ok {
+		resetTime := rl_err.Rate.Reset.Time
+		delaySeconds := int(time.Until(resetTime).Seconds())
+		log.Printf("RateLimits ratelimited, sleeping for %ds (at %s)", delaySeconds, resetTime.String())
+		return nil, delaySeconds
+	} else if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusForbidden {
+			if retryAfterSeconds, parseErr := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 32); parseErr == nil {
+				delaySeconds := int(retryAfterSeconds + (60 * rand.Int63n(randomDelaySeconds)))
+				log.Printf("RateLimits Retry-After %d seconds received, sleeping for %ds", retryAfterSeconds, delaySeconds)
+				return nil, delaySeconds
+			}
+		}
+		log.Printf("RateLimits error: %s", err.Error())
+		return nil, rateLimitsQuerySecondsBetween
+	}
+
+	return rateLimits, rateLimitsQuerySecondsBetween
+}
+
+// getRemainingLimitsFromGithub - return information about the remaining limits for this GitHub client's credentials
+func getRemainingLimitsFromGithub() {
+	for {
+		rateLimits, secondsBetween := getRateLimits()
+
+		if rateLimits != nil {
+			remainingLimitsGauge.WithLabelValues("core").Set(float64(rateLimits.GetCore().Remaining))
+			remainingLimitsGauge.WithLabelValues("search").Set(float64(rateLimits.GetSearch().Remaining))
+			remainingLimitsGauge.WithLabelValues("graphql").Set(float64(rateLimits.GetGraphQL().Remaining))
+		}
+
+		time.Sleep(time.Duration(secondsBetween) * time.Second)
+	}
+}

--- a/pkg/metrics/get_rate_limits_from_github.go
+++ b/pkg/metrics/get_rate_limits_from_github.go
@@ -15,8 +15,8 @@ import (
 var (
 	remainingLimitsGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "github_remaining_limits",
-			Help: "remaining limits",
+			Name: "github_remaining_limit",
+			Help: "number of requests remaining",
 		},
 		[]string{"type"},
 	)

--- a/pkg/metrics/get_rate_limits_from_github.go
+++ b/pkg/metrics/get_rate_limits_from_github.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/faubion-hbo/github-actions-exporter/pkg/config"
+
 	"github.com/google/go-github/v45/github"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -22,29 +24,27 @@ var (
 	)
 )
 
-var rateLimitsQuerySecondsBetween = 5
-
-func getRateLimits() (*github.RateLimits, int) {
+func getRateLimits() (*github.RateLimits, int64) {
 	rateLimits, resp, err := client.RateLimits(context.Background())
 
 	if rl_err, ok := err.(*github.RateLimitError); ok {
 		resetTime := rl_err.Rate.Reset.Time
-		delaySeconds := int(time.Until(resetTime).Seconds())
+		delaySeconds := int64(time.Until(resetTime).Seconds())
 		log.Printf("RateLimits ratelimited, sleeping for %ds (at %s)", delaySeconds, resetTime.String())
 		return nil, delaySeconds
 	} else if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusForbidden {
 			if retryAfterSeconds, parseErr := strconv.ParseInt(resp.Header.Get("Retry-After"), 10, 32); parseErr == nil {
-				delaySeconds := int(retryAfterSeconds + (60 * rand.Int63n(randomDelaySeconds)))
+				delaySeconds := retryAfterSeconds + (60 * rand.Int63n(randomDelaySeconds))
 				log.Printf("RateLimits Retry-After %d seconds received, sleeping for %ds", retryAfterSeconds, delaySeconds)
 				return nil, delaySeconds
 			}
 		}
 		log.Printf("RateLimits error: %s", err.Error())
-		return nil, rateLimitsQuerySecondsBetween
+		return nil, config.Github.Refresh
 	}
 
-	return rateLimits, rateLimitsQuerySecondsBetween
+	return rateLimits, config.Github.Refresh
 }
 
 // getRemainingLimitsFromGithub - return information about the remaining limits for this GitHub client's credentials

--- a/pkg/metrics/github_fetcher.go
+++ b/pkg/metrics/github_fetcher.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v45/github"
-
 	"github.com/faubion-hbo/github-actions-exporter/pkg/config"
+
+	"github.com/google/go-github/v45/github"
 )
 
 type orgRepos struct {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -47,6 +47,7 @@ func InitMetrics() {
 	prometheus.MustRegister(workflowRunDurationGauge)
 	prometheus.MustRegister(workflowBillGauge)
 	prometheus.MustRegister(runnersEnterpriseGauge)
+	prometheus.MustRegister(remainingLimitsGauge)
 
 	client, err = NewClient()
 	if err != nil {
@@ -66,6 +67,7 @@ func InitMetrics() {
 	go getRunnersOrganizationFromGithub()
 	go getWorkflowRunsFromGithub()
 	go getRunnersEnterpriseFromGithub()
+	go getRemainingLimitsFromGithub()
 }
 
 // NewClient creates a Github Client

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/faubion-hbo/github-actions-exporter/pkg/config"
@@ -68,7 +67,7 @@ func InitMetrics() {
 	go getRunnersOrganizationFromGithub()
 	go getWorkflowRunsFromGithub()
 	go getRunnersEnterpriseFromGithub()
-	go getRemainingLimitsFromGithub(strconv.FormatInt(config.Github.AppID, 10))
+	go getRemainingLimitsFromGithub()
 }
 
 // NewClient creates a Github Client

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/faubion-hbo/github-actions-exporter/pkg/config"
@@ -67,7 +68,7 @@ func InitMetrics() {
 	go getRunnersOrganizationFromGithub()
 	go getWorkflowRunsFromGithub()
 	go getRunnersEnterpriseFromGithub()
-	go getRemainingLimitsFromGithub()
+	go getRemainingLimitsFromGithub(strconv.FormatInt(config.Github.AppID, 10))
 }
 
 // NewClient creates a Github Client


### PR DESCRIPTION
only `core` is really used as of now, but other 2 have likely usage in the future. can add others if they become relevant.

adds the `github_remaining_limit` metric

## Testing

created a tmp GitHub App for this account, and was able to observe rate limit information after giving it sufficient permissions:

<img width="1550" alt="Screen Shot 2024-06-26 at 5 35 26 PM" src="https://github.com/faubion-hbo/github-actions-exporter/assets/61430347/6caa69a6-c41e-4d21-acc6-6495623b5ce7">
